### PR TITLE
Setup-Exercise-02: add missing import

### DIFF
--- a/DFCP-Python/_includes/Setup-Exercise-02.py
+++ b/DFCP-Python/_includes/Setup-Exercise-02.py
@@ -62,14 +62,14 @@ def no_white_space():
   return True
 
 def no_empty_strings():
-  from pyspark.sql.functions import col, trim, ltrim
+  from pyspark.sql.functions import col, trim, ltrim, lit
   for column in string_columns:
     if 0 != spark.read.format("delta").load(batch_target_path).filter(trim(col(column)) == lit("")).count():
       return False
   return True
 
 def no_null_strings():
-  from pyspark.sql.functions import col, trim, ltrim
+  from pyspark.sql.functions import col, trim, ltrim, lit
   for column in string_columns:
     if 0 != spark.read.format("delta").load(batch_target_path).filter(trim(col(column)) == lit("null")).count():
       return False


### PR DESCRIPTION
If you don't happen to import F.lit in your own code, then the functions no_empty_strings() and no_null_strings() would fail.